### PR TITLE
Add lodash to support nested cover fields.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,8 @@
 const fs = require('fs')
 const path = require('path')
 const yaml = require('js-yaml')
+const get = require("lodash/get")
+const set = require("lodash/set")
 const RemarkTransformer = require('@gridsome/transformer-remark')
 
 const markdownResolver = [
@@ -71,7 +73,7 @@ class NetlifyPaths {
         if (coverField !== undefined) {
           console.info(`Fixing cover images for ${typeName}.${coverField}`)
           ContentType.on('add', node => {
-            node[coverField] = this.fixPath(node[coverField])
+            set(node, coverField, this.fixPath(get(node, coverField)))
           })
         }
       }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "gridsome-plugin"
   ],
   "dependencies": {
-    "js-yaml": "^3.13.1"
+    "js-yaml": "^3.13.1",
+    "lodash": "^4.17.21"
   },
   "peerDependencies": {
     "@gridsome/transformer-remark": "^0.3.2",


### PR DESCRIPTION
## What
Added lodash to use _set and _get, in order to support nested cover fields.

## Why
The plugin doesn't currently support nested fields, and I would like it to.

I have a website that must be follow WCAG 2.1, and in order to help the web admins stay within those bounds, I must require alt descriptions on images, when the images aren't decorative.

This means I have a collection with a cover field that is an object and not an image.
![image](https://user-images.githubusercontent.com/9387114/118377638-bd5fe180-b5ce-11eb-9c61-3db04383cdea.png)

## How to use
The plugin will function as usual when accessing a direct field:
coverField: "cover"

To specify a nested field, simply access it like you would in Javascript code (with a dot in between):
coverField: "cover.image"